### PR TITLE
URL Update in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Kegboard with Kegbot, or something else.
 
 The main repository is located at: https://github.com/Kegbot/kegboard
 
-You can find more information about Kegboard at: http://kegbot.org/kegboard/
+You can find more information about Kegboard at: http://kegbot.org/docs/kegboard/
 
 ## More Info & Help
 


### PR DESCRIPTION
Not sure if the url is broken, been updated, or if it was just a typo…
old:
https://kegbot.org/kegboard/
new:
https://kegbot.org/docs/kegboard/
